### PR TITLE
default kwargs are evaluated at definition time

### DIFF
--- a/pythonwhois/net.py
+++ b/pythonwhois/net.py
@@ -2,7 +2,9 @@ import socket, re, sys
 from codecs import encode, decode
 from . import shared
 
-def get_whois_raw(domain, server="", previous=[], rfc3490=True, never_cut=False, with_server_list=False, server_list=[]):
+def get_whois_raw(domain, server="", previous=None, rfc3490=True, never_cut=False, with_server_list=False, server_list=None):
+	previous = previous or []
+	server_list = server_list or []
 	# Sometimes IANA simply won't give us the right root WHOIS server
 	exceptions = {
 		".ac.uk": "whois.ja.net",
@@ -20,7 +22,6 @@ def get_whois_raw(domain, server="", previous=[], rfc3490=True, never_cut=False,
 
 	if len(previous) == 0 and server == "":
 		# Root query
-		server_list = [] # Otherwise it retains the list on subsequent queries, for some reason.
 		is_exception = False
 		for exception, exc_serv in exceptions.items():
 			if domain.endswith(exception):

--- a/pythonwhois/parse.py
+++ b/pythonwhois/parse.py
@@ -426,7 +426,8 @@ else:
 		return isinstance(data, str)
 
 
-def parse_raw_whois(raw_data, normalized=[], never_query_handles=True, handle_server=""):
+def parse_raw_whois(raw_data, normalized=None, never_query_handles=True, handle_server=""):
+	normalized = normalized or []
 	data = {}
 
 	raw_data = [segment.replace("\r", "") for segment in raw_data] # Carriage returns are the devil


### PR DESCRIPTION
After seeing some strange behavior while trying to write unittests for my script which uses [python-whois](https://github.com/joepie91/python-whois), I thought I would go ahead and submit this patch. This PR addresses a comment made here:

https://github.com/joepie91/python-whois/commit/d86e4ba9166e80b8c66b093b355f3c32e94c0229#commitcomment-6967148

This stackoverflow question covers the topic pretty well:
[“Least Astonishment” in Python: The Mutable Default Argument](http://stackoverflow.com/q/1132941/1547030)

From docs.python.org:

> Default parameter values are evaluated when the function definition is
> executed. This means that the expression is evaluated once, when the
> function is defined, and that the same “pre-computed” value is used for
> each call. This is especially important to understand when a default
> parameter is a mutable object, such as a list or a dictionary: if the
> function modifies the object (e.g. by appending an item to a list), the
> default value is in effect modified. This is generally not what was
> intended. A way around this is to use None as the default, and
> explicitly test for it in the body of the function
> 
> https://docs.python.org/2/reference/compound_stmts.html#function-definitions
