### PR TITLE
Fix for unexpected decoding errors. 

### DIFF
--- a/pythonwhois/net.py
+++ b/pythonwhois/net.py
@@ -14,7 +14,7 @@ def get_whois_raw(domain, server="", previous=None, rfc3490=True, never_cut=Fals
 		# The following is a bit hacky, but IANA won't return the right answer for example.com because it's a direct registration.
 		"example.com": "whois.verisign-grs.com"
 	}
-	
+
 	if rfc3490:
 		if sys.version_info < (3, 0):
 			domain = encode( domain if type(domain) is unicode else decode(domain, "utf8"), "idna" )
@@ -71,7 +71,7 @@ def get_whois_raw(domain, server="", previous=None, rfc3490=True, never_cut=Fals
 		return (new_list, server_list)
 	else:
 		return new_list
-	
+
 def get_root_server(domain):
 	data = whois_request(domain, "whois.iana.org")
 	for line in [x.strip() for x in data.splitlines()]:
@@ -80,7 +80,7 @@ def get_root_server(domain):
 			continue
 		return match.group(1)
 	raise shared.WhoisException("No root WHOIS server found for domain.")
-	
+
 def whois_request(domain, server, port=43):
 	sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 	sock.connect((server, port))
@@ -91,4 +91,10 @@ def whois_request(domain, server, port=43):
 		if len(data) == 0:
 			break
 		buff += data
-	return buff.decode("utf-8")
+	encodings = ("utf-8", "iso-8859-1")
+	for encoding in encodings: # This should probably not be a permanent solution.
+		try:
+			return buff.decode(encoding)
+		except ValueError:
+			pass
+	raise ValueError("Could not decode whois response from {server}".format(server=server))


### PR DESCRIPTION
Now pythonwhois no longer raises a `UnicodeDecodeError` whenever a response uses a non-UTF-8 encoding. It instead goes through UTF-8 and ISO-8859-1, and is easily extensible to other encodings Python supports. If it goes through the entire list of encodings without managing to decode the page, it raises a `ValueError` with the server in it for easy error spotting.

This should fix issue #57, but I'll leave that determination to someone else. As noted in that issue's comments, there could be other ways to do this.
