### PR TITLE
Add support for passing a timeout through to the whois query

### DIFF
--- a/pythonwhois/__init__.py
+++ b/pythonwhois/__init__.py
@@ -1,7 +1,7 @@
 from . import net, parse
 
-def get_whois(domain, normalized=[]):
-	raw_data, server_list = net.get_whois_raw(domain, with_server_list=True)
+def get_whois(domain, normalized=[], timeout=None):
+	raw_data, server_list = net.get_whois_raw(domain, with_server_list=True, timeout=None)
 	# Unlisted handles will be looked up on the last WHOIS server that was queried. This may be changed to also query
 	# other servers in the future, if it turns out that there are cases where the last WHOIS server in the chain doesn't
 	# actually hold the handle contact details, but another WHOIS server in the chain does.


### PR DESCRIPTION
When using pythonwhois for large numbers of queries, I find sometimes a whois query will hang (probably rate-limiting on the whois server)

It is useful to be able to put a timeout on the whois query so that the thread/application can recover from this failure.

This patch allows the get_whois caller to specify an optional timeout that will be applied to any connections to whois servers.
