### PR TITLE
fixed issue with encoding

### DIFF
--- a/pythonwhois/net.py
+++ b/pythonwhois/net.py
@@ -91,4 +91,4 @@ def whois_request(domain, server, port=43):
 		if len(data) == 0:
 			break
 		buff += data
-	return buff.decode("utf-8")
+	return buff.decode("utf-8", 'ignore')


### PR DESCRIPTION
as an example, AS2602 crashed pythonwhois because there is a \xe9 non-utf8 character in the address field.