### PR TITLE
solves: /usr/local/lib/python3.6/site-packages/pythonwhois/net.py:44:…

### DIFF
--- a/pythonwhois/net.py
+++ b/pythonwhois/net.py
@@ -91,4 +91,5 @@ def whois_request(domain, server, port=43):
 		if len(data) == 0:
 			break
 		buff += data
+	sock.close()
 	return buff.decode("utf-8")


### PR DESCRIPTION
solves: /usr/local/lib/python3.6/site-packages/pythonwhois/net.py:44:…  …
… ResourceWarning: unclosed <socket.socket fd=3, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('...', 50937), raddr=('...', 43)>