### PR TITLE
Adding missing regex escapes in parse.py preprocess_regex() function - Issue #142

### DIFF
--- a/pythonwhois/parse.py
+++ b/pythonwhois/parse.py
@@ -202,7 +202,7 @@ grammar = {
 
 def preprocess_regex(regex):
 	# Fix for #2; prevents a ridiculous amount of varying size permutations.
-	regex = re.sub(r"\\s\*\(\?P<([^>]+)>\.\+\)", r"\s*(?P<\1>\S.*)", regex)
+	regex = re.sub(r"\\s\*\(\?P<([^>]+)>\.\+\)", r"\\s*(?P<\1>\\S.*)", regex)
 	# Experimental fix for #18; removes unnecessary variable-size whitespace
 	# matching, since we're stripping results anyway.
 	regex = re.sub(r"\[ \]\*\(\?P<([^>]+)>\.\*\)", r"(?P<\1>.*)", regex)


### PR DESCRIPTION
This fix is fixing the Issue #142 for python > 3.6.
I run `./test.py all` and everything went fine.