### PR TITLE
Python 3.7 compatibility due to new requirements to re.sub repl.

### DIFF
--- a/pythonwhois/parse.py
+++ b/pythonwhois/parse.py
@@ -202,7 +202,7 @@ grammar = {
 
 def preprocess_regex(regex):
 	# Fix for #2; prevents a ridiculous amount of varying size permutations.
-	regex = re.sub(r"\\s\*\(\?P<([^>]+)>\.\+\)", r"\s*(?P<\1>\S.*)", regex)
+	regex = re.sub(r"\\s\*\(\?P<([^>]+)>\.\+\)", r"\\s*(?P<\1>\\S.*)", regex)
 	# Experimental fix for #18; removes unnecessary variable-size whitespace
 	# matching, since we're stripping results anyway.
 	regex = re.sub(r"\[ \]\*\(\?P<([^>]+)>\.\*\)", r"(?P<\1>.*)", regex)


### PR DESCRIPTION
Hello,

small changes to pass tests in python 3.7. 

Before changes:

```
python3.7 test.py run all
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/sre_parse.py", line 1021, in parse_template
    this = chr(ESCAPES[this][1])
KeyError: '\\s'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "test.py", line 3, in <module>
    import sys, argparse, os, pythonwhois, json, datetime, codecs, time
  File "/home/yura/github/pythonwhois-py3/pythonwhois/__init__.py", line 1, in <module>
    from . import net, parse
  File "/home/yura/github/pythonwhois-py3/pythonwhois/parse.py", line 363, in <module>
    registrant_regexes = [preprocess_regex(regex) for regex in registrant_regexes]
  File "/home/yura/github/pythonwhois-py3/pythonwhois/parse.py", line 363, in <listcomp>
    registrant_regexes = [preprocess_regex(regex) for regex in registrant_regexes]
  File "/home/yura/github/pythonwhois-py3/pythonwhois/parse.py", line 205, in preprocess_regex
    regex = re.sub(r"\\s\*\(\?P<([^>]+)>\.\+\)", r"\s*(?P<\1>\S.*)", regex)
  File "/usr/local/lib/python3.7/re.py", line 192, in sub
    return _compile(pattern, flags).sub(repl, string, count)
  File "/usr/local/lib/python3.7/re.py", line 309, in _subx
    template = _compile_repl(template, pattern)
  File "/usr/local/lib/python3.7/re.py", line 300, in _compile_repl
    return sre_parse.parse_template(repl, pattern)
  File "/usr/local/lib/python3.7/sre_parse.py", line 1024, in parse_template
    raise s.error('bad escape %s' % this, len(this))
re.error: bad escape \s at position 0
```

The problem is 
> repl can be a string or a function; if it is a string, any backslash escapes in it are processed. That is, \n is converted to a single newline character, \r is converted to a carriage return, and so forth. Unknown escapes of ASCII letters are reserved for future use and treated as errors.
https://docs.python.org/3/library/re.html#re.sub

After all tests pass:

```
python3.6 test.py run all
[  1/244] 0007games.com passed in normalized mode.
[  2/244] 0007games.com passed in default mode.
[  3/244] 0031fashion.com passed in normalized mode.
[  4/244] 0031fashion.com passed in default mode.
[  5/244] 123vitamine.com passed in normalized mode.
[  6/244] 123vitamine.com passed in default mode.
[  7/244] 2x4.ru passed in normalized mode.
[  8/244] 2x4.ru passed in default mode.
[  9/244] 365calendars.com passed in normalized mode.
[ 10/244] 365calendars.com passed in default mode.
[ 11/244] 9v.lt passed in normalized mode.
[ 12/244] 9v.lt passed in default mode.
[ 13/244] about.museum passed in normalized mode.
[ 14/244] about.museum passed in default mode.
[ 15/244] abouttubes.com passed in normalized mode.
[ 16/244] abouttubes.com passed in default mode.
[ 17/244] actu.org.au passed in normalized mode.
[ 18/244] actu.org.au passed in default mode.
[ 19/244] alibaba.jp passed in normalized mode.
[ 20/244] alibaba.jp passed in default mode.
[ 21/244] alliancefrançaise.nu passed in normalized mode.
[ 22/244] alliancefrançaise.nu passed in default mode.
[ 23/244] anink.com passed in normalized mode.
[ 24/244] anink.com passed in default mode.
[ 25/244] anonne.ws passed in normalized mode.
[ 26/244] anonne.ws passed in default mode.
[ 27/244] anonnews.org passed in normalized mode.
[ 28/244] anonnews.org passed in default mode.
[ 29/244] aol.com passed in normalized mode.
[ 30/244] aol.com passed in default mode.
[ 31/244] aridns.net.au passed in normalized mode.
[ 32/244] aridns.net.au passed in default mode.
[ 33/244] arkeysolutions.com passed in normalized mode.
[ 34/244] arkeysolutions.com passed in default mode.
[ 35/244] asiahotel.co.th passed in normalized mode.
[ 36/244] asiahotel.co.th passed in default mode.
[ 37/244] atheme.org passed in normalized mode.
[ 38/244] atheme.org passed in default mode.
[ 39/244] australia.gov.au passed in normalized mode.
[ 40/244] australia.gov.au passed in default mode.
[ 41/244] b.ro passed in normalized mode.
[ 42/244] b.ro passed in default mode.
[ 43/244] baligems.co.uk passed in normalized mode.
[ 44/244] baligems.co.uk passed in default mode.
[ 45/244] blackburn.ac.uk passed in normalized mode.
[ 46/244] blackburn.ac.uk passed in default mode.
[ 47/244] bristol.ac.uk passed in normalized mode.
[ 48/244] bristol.ac.uk passed in default mode.
[ 49/244] bts.co.th passed in normalized mode.
[ 50/244] bts.co.th passed in default mode.
[ 51/244] byme.at passed in normalized mode.
[ 52/244] byme.at passed in default mode.
[ 53/244] bäckerei.de passed in normalized mode.
[ 54/244] bäckerei.de passed in default mode.
[ 55/244] communigal.net passed in normalized mode.
[ 56/244] communigal.net passed in default mode.
[ 57/244] cryto.net passed in normalized mode.
[ 58/244] cryto.net passed in default mode.
[ 59/244] daemonrage.net passed in normalized mode.
[ 60/244] daemonrage.net passed in default mode.
[ 61/244] davicom.com.tw passed in normalized mode.
[ 62/244] davicom.com.tw passed in default mode.
[ 63/244] defunctkernel.me passed in normalized mode.
[ 64/244] defunctkernel.me passed in default mode.
[ 65/244] direct.gov.uk passed in normalized mode.
[ 66/244] direct.gov.uk passed in default mode.
[ 67/244] dns4pro.com passed in normalized mode.
[ 68/244] dns4pro.com passed in default mode.
[ 69/244] donuts.co passed in normalized mode.
[ 70/244] donuts.co passed in default mode.
[ 71/244] drpciv.biz passed in normalized mode.
[ 72/244] drpciv.biz passed in default mode.
[ 73/244] edis.at passed in normalized mode.
[ 74/244] edis.at passed in default mode.
[ 75/244] engine.com passed in normalized mode.
[ 76/244] engine.com passed in default mode.
[ 77/244] evalsed.info passed in normalized mode.
[ 78/244] evalsed.info passed in default mode.
[ 79/244] example.com passed in normalized mode.
[ 80/244] example.com passed in default mode.
[ 81/244] expopack.com.mx passed in normalized mode.
[ 82/244] expopack.com.mx passed in default mode.
[ 83/244] f63.net passed in normalized mode.
[ 84/244] f63.net passed in default mode.
[ 85/244] formule1fo.com passed in normalized mode.
[ 86/244] formule1fo.com passed in default mode.
[ 87/244] foxiepa.ws passed in normalized mode.
[ 88/244] foxiepa.ws passed in default mode.
[ 89/244] geko.dk passed in normalized mode.
[ 90/244] geko.dk passed in default mode.
[ 91/244] get.moe passed in normalized mode.
[ 92/244] get.moe passed in default mode.
[ 93/244] globallatedeals.com passed in normalized mode.
[ 94/244] globallatedeals.com passed in default mode.
[ 95/244] globaltravelgroup.com passed in normalized mode.
[ 96/244] globaltravelgroup.com passed in default mode.
[ 97/244] google.cn passed in normalized mode.
[ 98/244] google.cn passed in default mode.
[ 99/244] google.co.jp passed in normalized mode.
[100/244] google.co.jp passed in default mode.
[101/244] google.co.th passed in normalized mode.
[102/244] google.co.th passed in default mode.
[103/244] google.co.uk passed in normalized mode.
[104/244] google.co.uk passed in default mode.
[105/244] google.com passed in normalized mode.
[106/244] google.com passed in default mode.
[107/244] google.com.tw passed in normalized mode.
[108/244] google.com.tw passed in default mode.
[109/244] google.it passed in normalized mode.
[110/244] google.it passed in default mode.
[111/244] hl3.eu passed in normalized mode.
[112/244] hl3.eu passed in default mode.
[113/244] hopjb.eu passed in normalized mode.
[114/244] hopjb.eu passed in default mode.
[115/244] huskeh.net passed in normalized mode.
[116/244] huskeh.net passed in default mode.
[117/244] hyves.nl passed in normalized mode.
[118/244] hyves.nl passed in default mode.
[119/244] imperial.ac.uk passed in normalized mode.
[120/244] imperial.ac.uk passed in default mode.
[121/244] ireland.ie passed in normalized mode.
[122/244] ireland.ie passed in default mode.
[123/244] ismtgoxdeadyet.com passed in normalized mode.
[124/244] ismtgoxdeadyet.com passed in default mode.
[125/244] jizzbo.com passed in normalized mode.
[126/244] jizzbo.com passed in default mode.
[127/244] keybase.io passed in normalized mode.
[128/244] keybase.io passed in default mode.
[129/244] linux.conf.au passed in normalized mode.
[130/244] linux.conf.au passed in default mode.
[131/244] lowendbox.com passed in normalized mode.
[132/244] lowendbox.com passed in default mode.
[133/244] lowendshare.com passed in normalized mode.
[134/244] lowendshare.com passed in default mode.
[135/244] microsoft.com passed in normalized mode.
[136/244] microsoft.com passed in default mode.
[137/244] mu.oz.au passed in normalized mode.
[138/244] mu.oz.au passed in default mode.
[139/244] nepasituation.com passed in normalized mode.
[140/244] nepasituation.com passed in default mode.
[141/244] nic.buzz passed in normalized mode.
[142/244] nic.buzz passed in default mode.
[143/244] nic.ir passed in normalized mode.
[144/244] nic.ir passed in default mode.
[145/244] nic.ps passed in normalized mode.
[146/244] nic.ps passed in default mode.
[147/244] nic.pw passed in normalized mode.
[148/244] nic.pw passed in default mode.
[149/244] nic.ru passed in normalized mode.
[150/244] nic.ru passed in default mode.
[151/244] nominet.org.uk passed in normalized mode.
[152/244] nominet.org.uk passed in default mode.
[153/244] nsa.gov passed in normalized mode.
[154/244] nsa.gov passed in default mode.
[155/244] nttpc.co.jp passed in normalized mode.
[156/244] nttpc.co.jp passed in default mode.
[157/244] nytimes.com passed in normalized mode.
[158/244] nytimes.com passed in default mode.
[159/244] oli.id.au passed in normalized mode.
[160/244] oli.id.au passed in default mode.
[161/244] ovh.fr passed in normalized mode.
[162/244] ovh.fr passed in default mode.
[163/244] pcmups.com.tw passed in normalized mode.
[164/244] pcmups.com.tw passed in default mode.
[165/244] pixelmania.asia passed in normalized mode.
[166/244] pixelmania.asia passed in default mode.
[167/244] porn.com.tw passed in normalized mode.
[168/244] porn.com.tw passed in default mode.
[169/244] prq.se passed in normalized mode.
[170/244] prq.se passed in default mode.
[171/244] quadranet.com passed in normalized mode.
[172/244] quadranet.com passed in default mode.
[173/244] realtek.com.tw passed in normalized mode.
[174/244] realtek.com.tw passed in default mode.
[175/244] redd.it passed in normalized mode.
[176/244] redd.it passed in default mode.
[177/244] ricoh.co.th passed in normalized mode.
[178/244] ricoh.co.th passed in default mode.
[179/244] rs.co.th passed in normalized mode.
[180/244] rs.co.th passed in default mode.
[181/244] servequake.com passed in normalized mode.
[182/244] servequake.com passed in default mode.
[183/244] siamparagon.co.th passed in normalized mode.
[184/244] siamparagon.co.th passed in default mode.
[185/244] simpardaz.com passed in normalized mode.
[186/244] simpardaz.com passed in default mode.
[187/244] sina.com.cn passed in normalized mode.
[188/244] sina.com.cn passed in default mode.
[189/244] singularity.fr passed in normalized mode.
[190/244] singularity.fr passed in default mode.
[191/244] starbucks.co.th passed in normalized mode.
[192/244] starbucks.co.th passed in default mode.
[193/244] swisscom.ch passed in normalized mode.
[194/244] swisscom.ch passed in default mode.
[195/244] sydney.edu.au passed in normalized mode.
[196/244] sydney.edu.au passed in default mode.
[197/244] test.de passed in normalized mode.
[198/244] test.de passed in default mode.
[199/244] textfiles.com passed in normalized mode.
[200/244] textfiles.com passed in default mode.
[201/244] theregister.com passed in normalized mode.
[202/244] theregister.com passed in default mode.
[203/244] tip.it passed in normalized mode.
[204/244] tip.it passed in default mode.
[205/244] toyota.co.th passed in normalized mode.
[206/244] toyota.co.th passed in default mode.
[207/244] twitter.com passed in normalized mode.
[208/244] twitter.com passed in default mode.
[209/244] ufpa.br passed in normalized mode.
[210/244] ufpa.br passed in default mode.
[211/244] unwire.hk passed in normalized mode.
[212/244] unwire.hk passed in default mode.
[213/244] urlte.am passed in normalized mode.
[214/244] urlte.am passed in default mode.
[215/244] via.com.tw passed in normalized mode.
[216/244] via.com.tw passed in default mode.
[217/244] vulnweb.com passed in normalized mode.
[218/244] vulnweb.com passed in default mode.
[219/244] wa.us passed in normalized mode.
[220/244] wa.us passed in default mode.
[221/244] warwick.ac.uk passed in normalized mode.
[222/244] warwick.ac.uk passed in default mode.
[223/244] whirlpool.net.au passed in normalized mode.
[224/244] whirlpool.net.au passed in default mode.
[225/244] whois.com passed in normalized mode.
[226/244] whois.com passed in default mode.
[227/244] whois.us passed in normalized mode.
[228/244] whois.us passed in default mode.
[229/244] whoiser.ir passed in normalized mode.
[230/244] whoiser.ir passed in default mode.
[231/244] winamp.com passed in normalized mode.
[232/244] winamp.com passed in default mode.
[233/244] wosoccer.com passed in normalized mode.
[234/244] wosoccer.com passed in default mode.
[235/244] x.it passed in normalized mode.
[236/244] x.it passed in default mode.
[237/244] xboxmoments.com passed in normalized mode.
[238/244] xboxmoments.com passed in default mode.
[239/244] yahoo.com.tw passed in normalized mode.
[240/244] yahoo.com.tw passed in default mode.
[241/244] yahoo.it passed in normalized mode.
[242/244] yahoo.it passed in default mode.
[243/244] zem.org.uk passed in normalized mode.
[244/244] zem.org.uk passed in default mode.
Timing in default mode: 20ms avg, 0ms min, 76ms max
Timing in normalized mode: 20ms avg, 0ms min, 76ms max
All tests passed!
```

After this changes test on python2.7 and python3.6 also pass.