### PR TITLE
docs: fix simple typo, succesfull -> successful

### DIFF
--- a/test.py
+++ b/test.py
@@ -17,7 +17,7 @@ def get_codecs():
 
 
 def read_encoded_file(file_path):
-	"""Try reading file using all codecs. Return the first succesfull one."""
+	"""Try reading file using all codecs. Return the first successful one."""
 	for encoding in get_codecs():
 		try:
 			with codecs.open(file_path, "r", encoding) as f:


### PR DESCRIPTION
There is a small typo in test.py.

Should read `successful` rather than `succesfull`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md